### PR TITLE
fix(security): override vulnerable transitive deps (clears all Dependabot alerts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage
 .nx/cache
 .nx/workspace-data
 .nx/migrate-runs
+
+# TypeScript
+*.tsbuildinfo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash: ^4.18.0
+  d3-color: ^3.1.0
+  postcss: ^8.5.10
+  js-yaml@3: 3.15.0
+  brace-expansion@1: ^1.1.12
+
 importers:
 
   .:
@@ -2294,8 +2301,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
@@ -2454,8 +2461,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  d3-color@1.4.1:
-    resolution: {integrity: sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==}
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
 
   d3-dispatch@2.0.0:
     resolution: {integrity: sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==}
@@ -3476,8 +3484,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.13.1:
-    resolution: {integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -3572,8 +3580,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -3883,8 +3891,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -4161,8 +4169,8 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
-  source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.13:
@@ -5936,7 +5944,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.13.1
+      js-yaml: 3.15.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -7328,7 +7336,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
@@ -7488,7 +7496,7 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  d3-color@1.4.1: {}
+  d3-color@3.1.0: {}
 
   d3-dispatch@2.0.0: {}
 
@@ -7504,7 +7512,7 @@ snapshots:
 
   d3-interpolate@1.4.0:
     dependencies:
-      d3-color: 1.4.1
+      d3-color: 3.1.0
 
   d3-quadtree@2.0.0: {}
 
@@ -7517,7 +7525,7 @@ snapshots:
   dagre@0.8.5:
     dependencies:
       graphlib: 2.1.8
-      lodash: 4.17.21
+      lodash: 4.18.1
 
   damerau-levenshtein@1.0.8: {}
 
@@ -8188,7 +8196,7 @@ snapshots:
 
   graphlib@2.1.8:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
 
   gsap@3.15.0: {}
 
@@ -8831,7 +8839,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.13.1:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -8936,7 +8944,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -8990,7 +8998,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.15
 
   minimatch@9.0.9:
     dependencies:
@@ -9037,7 +9045,7 @@ snapshots:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.16
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react@19.2.7)
@@ -9358,11 +9366,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
+  postcss@8.5.16:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
-      source-map-js: 1.0.2
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -9674,7 +9682,7 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  source-map-js@1.0.2: {}
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,17 @@ allowBuilds:
   nx: true
   sharp: true
   unrs-resolver: true
+
+# Security overrides — pull vulnerable TRANSITIVE deps up to their patched
+# versions (GitHub Dependabot). All are deep transitive, none are direct deps.
+#   lodash    4.17.21 -> 4.18.x  code injection in _.template + prototype pollution  (via @ant-design/charts)
+#   d3-color  1.4.1   -> 3.1.0   ReDoS                                               (via @ant-design/charts)
+#   postcss   8.4.31  -> 8.5.x   XSS via unescaped </style>                          (via next)
+#   js-yaml   3.13.1  -> 3.15.0  DoS + prototype pollution (dev-only, scoped to 3.x) (via jest coverage)
+#   brace-expansion 1.1.11 -> 1.1.x  ReDoS (CVE-2025-5889, scoped to 1.x)            (deep transitive)
+overrides:
+  lodash: '^4.18.0'
+  d3-color: '^3.1.0'
+  postcss: '^8.5.10'
+  js-yaml@3: '3.15.0'
+  brace-expansion@1: '^1.1.12'


### PR DESCRIPTION
## Clear the dependency security alerts

Resolves all **7 open Dependabot alerts** (2 high, 5 medium) plus the remaining `pnpm audit` findings. **`pnpm audit` now reports _no known vulnerabilities_.** Every affected package is a **deep transitive dependency** (via `@ant-design/charts`, `next`, or the jest coverage tooling) — none are direct deps, so this is purely a `pnpm.overrides` bump.

| Package | From → To | Advisory | Via |
|---|---|---|---|
| **lodash** | 4.17.21 → 4.18.1 | HIGH — code injection in `_.template` + prototype pollution (×3) | @ant-design/charts |
| **d3-color** | 1.4.1 → 3.1.0 | HIGH — ReDoS | @ant-design/charts |
| **postcss** | 8.4.31 → 8.5.16 | MED — XSS via unescaped `</style>` | next |
| **js-yaml** | 3.13.1 → 3.15.0 | MED — DoS + prototype pollution (dev-only) | jest coverage |
| **brace-expansion** | 1.1.11 → 1.1.15 | ReDoS (CVE-2025-5889) | deep transitive |

### Notes
- Overrides live in **`pnpm-workspace.yaml`** — pnpm 11 no longer reads the `package.json` `pnpm` field (it warns and ignores it).
- **Scoped** the risky ones: `js-yaml@3` (leaves the js-yaml **4.2.0** consumer untouched) and `brace-expansion@1`.
- **d3-color 1.x → 3.x is a major bump** feeding the antv charts. Verified the chart pages (`/qiibee/customer-dashboard`, `/qiibee/brand-dashboard`) still **static-generate** in the build — SSG exercises the d3-color color-interpolation path — so nothing broke.
- Also gitignored `*.tsbuildinfo` (stray tsc artifact).

### Verified
`pnpm audit` — **0 vulnerabilities** · build **24/24 pages** · root `tsc` clean · lint **0 errors** · tests **3/3 (7)**