### PR TITLE
refactor: replace <img> with next/image; clear the remaining lint warnings

### DIFF
--- a/components/Portfolio/Cases/index.tsx
+++ b/components/Portfolio/Cases/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 // import { ReactComponent as ArrowPrevious } from '../assets/arrow-left.svg';
 // import ArrowNext from '../../../public/images/';
 import { CasesContainer } from './styles';
@@ -50,7 +51,7 @@ const Cases = () => (
       </div>
 
       <div className="row">
-        {CASE_STUDIES.map(({ // eslint-disable-next-line no-unused-vars
+        {CASE_STUDIES.map(({
           id, subtitle, title, img,
         }) => (
           <div className="case" key={id}>
@@ -60,7 +61,13 @@ const Cases = () => (
             </div>
 
             <div className="case-image">
-              <img src={`/images/${img}.png`} alt={title} />
+              <Image
+                src={`/images/${img}.png`}
+                alt={title}
+                fill
+                sizes="33vw"
+                style={{ objectFit: 'cover' }}
+              />
             </div>
           </div>
         ))}

--- a/libs/appbase/src/lib/circles.tsx
+++ b/libs/appbase/src/lib/circles.tsx
@@ -37,8 +37,10 @@ export const ApproachOne = () => {
   }, []);
 
   /* Timer-driven state machine: lock positions are derived from `counter` on
-     each tick, so these setState-in-effect calls are intentional. */
-  /* eslint-disable react-hooks/set-state-in-effect */
+     each tick, so the setState-in-effect calls are intentional — and the effect
+     is deliberately keyed to `counter` only (reading `lockOne`/`lockTwo` as
+     current state, not as triggers), so exhaustive-deps is disabled here too. */
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
   useEffect(() => {
     /* in case of ODD => update only 1st circle */
     if (counter % 2 === 1) {
@@ -57,7 +59,7 @@ export const ApproachOne = () => {
       });
     }
   }, [counter]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   return (
     <>

--- a/libs/cogsy/src/lib/Card/helper.tsx
+++ b/libs/cogsy/src/lib/Card/helper.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Image from 'next/image';
 import { InactiveStarIcon, ActiveStarIcon, KebabIcon } from '../Helpers/icons';
 import {
   MenuContainer,
@@ -39,7 +40,7 @@ export const Header = ({ source = null, sourceType = null }: HeaderProps) => {
       )}
 
       {sourceType === 'img' && typeof source === 'string' && (
-        <img src={source} alt={source} />
+        <Image src={source} alt={source} width={280} height={180} unoptimized />
       )}
     </HeaderContainer>
   );

--- a/libs/dashboard/src/lib/ClientMessages/index.tsx
+++ b/libs/dashboard/src/lib/ClientMessages/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { FaSearch, FaStar, FaRegStar } from 'react-icons/fa';
 import {
   MessagesContainer,
@@ -83,7 +84,7 @@ const ClientMessages = () => (
       }) => (
         <EachMessage key={id}>
           <Avatar>
-            <img src={`/images/${imageName}.jpg`} alt="" />
+            <Image src={`/images/${imageName}.jpg`} alt="" width={50} height={50} />
           </Avatar>
 
           <Content>

--- a/libs/dashboard/src/lib/Layout/TopNavBar/index.tsx
+++ b/libs/dashboard/src/lib/Layout/TopNavBar/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { FaPlusCircle, FaRegBell } from 'react-icons/fa';
 import {
   LeftNavBarContainer, ColumnOne, ColumnTwo, Logo,
@@ -29,7 +30,7 @@ const LeftNavBar = () => (
       <span className="divider" />
 
       <div className="profile-picture">
-        <img src="/images/girl_1.jpg" alt="Profile" />
+        <Image src="/images/girl_1.jpg" alt="Profile" width={38} height={38} />
       </div>
 
       <HyperLink

--- a/libs/qiibee/src/lib/Customer/List/index.tsx
+++ b/libs/qiibee/src/lib/Customer/List/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { connect } from 'react-redux';
 import {
   Button, Card, Col, Row, Tooltip,
@@ -71,9 +72,12 @@ const Brands = ({
             <BrandCard
               hoverable
               cover={(
-                <img
+                <Image
                   alt="example"
                   src={icon || 'https://fakeimg.pl/250x160?text="No+Image'}
+                  width={280}
+                  height={150}
+                  unoptimized
                 />
               )}
               actions={[

--- a/libs/taikai/src/lib/List/index.tsx
+++ b/libs/taikai/src/lib/List/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { FaSearchengin } from 'react-icons/fa';
 import JobDetails from '../JobDetails';
 import { Employees } from '../Helpers';
@@ -40,7 +41,7 @@ export const List = ({ pageNumber = 1, list = [] }: ListProps) => {
           <CompanyContainer key={id}>
             <CompanyInfo>
               <Avatar>
-                <img src={`/images/${logo}.jpg`} alt="" />
+                <Image src={`/images/${logo}.jpg`} alt="" width={50} height={50} />
               </Avatar>
 
               <div>

--- a/libs/timer/src/lib/index.tsx
+++ b/libs/timer/src/lib/index.tsx
@@ -34,7 +34,7 @@ const StopWatch = ({ initial = '0', interval = '1' }: StopWatchProps) => {
     } else if (timerRef.current) {
       clearInterval(timerRef.current);
     }
-  }, [isTimerOn]);
+  }, [isTimerOn, interval]);
 
   const minutes = Math.floor((duration % 3600) / 60);
   const seconds = Math.floor(duration % 60);

--- a/libs/weather-app/src/lib/Weather/index.tsx
+++ b/libs/weather-app/src/lib/Weather/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { Card } from 'antd';
 import { getCurrentFromTime } from '../utils';
 import { Cards } from '../styles';
@@ -34,9 +35,12 @@ const Weather = ({ isCelcius = false, active = 0, list = [] }: WeatherProps) => 
         <Card
           key={key}
           cover={(
-            <img
+            <Image
               alt={weatherMain}
               src={`http://openweathermap.org/img/w/${weatherIcon}.png`}
+              width={50}
+              height={50}
+              unoptimized
             />
           )}
           className={index === active ? 'active' : ''}

--- a/pages/my-css/1.tsx
+++ b/pages/my-css/1.tsx
@@ -1,6 +1,6 @@
-/* eslint-disable jsx-a11y/alt-text */
 import React from 'react';
 import styled from 'styled-components';
+import Image from 'next/image';
 
 export const Container = styled.div`
   display: flex;
@@ -30,17 +30,29 @@ export const Container = styled.div`
 function Carousel() {
   return (
     <Container>
-      <img
+      <Image
         className="slide"
         src="https://images.unsplash.com/photo-1559757849-1331b7beb222"
+        alt=""
+        width={320}
+        height={500}
+        unoptimized
       />
-      <img
+      <Image
         className="slide"
         src="https://images.unsplash.com/photo-1559757742-654d5da2eaab"
+        alt=""
+        width={320}
+        height={500}
+        unoptimized
       />
-      <img
+      <Image
         className="slide"
         src="https://images.unsplash.com/photo-1559757740-e85122cb7466"
+        alt=""
+        width={320}
+        height={500}
+        unoptimized
       />
     </Container>
   );

--- a/pages/my-css/3.tsx
+++ b/pages/my-css/3.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import Image from 'next/image';
 
 // REFLECTION
 
@@ -18,11 +19,12 @@ export const ContainerOne = styled.div`
 function Carousel() {
   return (
     <ContainerOne>
-      <img
+      <Image
         src="https://avatars.githubusercontent.com/u/22061815?v=4"
         width={300}
         height={300}
         alt="mohan"
+        unoptimized
       />
     </ContainerOne>
   );


### PR DESCRIPTION
Takes `pnpm lint` from **13 warnings → 0** by converting every `<img>` to `next/image` (your choice) and resolving the 2 react-hooks warnings.

## `<img>` → `next/image` (11 sites)
**Local images** — keep their existing container CSS; each gets explicit `width`/`height` matching its container so there's no aspect-ratio shift:
- Portfolio `Cases` — uses `fill` (its `.case-image` is already `position:absolute`)
- dashboard profile avatar (38×38) + client-message avatars (50×50)
- taikai company logo (50×50)

**Remote / dynamic srcs** — use `unoptimized`, because their hostnames are variable (data-driven or third-party). This upgrades them off `<img>` without coupling `next.config` to specific domains or risking "hostname not configured" at runtime:
- cogsy card image (data-driven `source`), qiibee brand cover (`icon` ?? fakeimg), weather-app icon (openweathermap), and the `my-css` practice pages (unsplash / gh avatar)
- added the now-required `alt` on the `my-css` slides and dropped that file's now-unused `jsx-a11y/alt-text` disable

## `react-hooks/exhaustive-deps` (2)
- **timer** — add the genuinely-missing `interval` prop to the effect deps. It's a stable prop in practice, so runtime behaviour is unchanged (and it's now correct if it ever changes).
- **appbase/circles** — the effect is a timer-driven state machine keyed to `counter` ticks only (`lockOne`/`lockTwo` are read as *current state*, not triggers); adding them would change the timing. Folded `exhaustive-deps` into the existing documented disable block rather than break the logic.

Also removed a stray unused `eslint-disable` in `Cases` (the last `[null]` warning).

## Verification
- `eslint .` — **0 errors, 0 warnings** (was 13 warnings)
- `nx run-many -t typecheck` — 13/13
- `pnpm build` — 24/24
- `pnpm testc` — 4 suites / 7 tests (dashboard's test exercises `next/image` under jsdom)

> ⚠️ **Visual note:** these are hand-tuned demo/take-home layouts and I can't render them headlessly, so please eyeball the affected screens once — especially Portfolio `Cases` (switched to `fill`/`object-fit: cover`, a slight change from the old natural-size clip).

Independent of #38 (touches component source, not the tests/config it changes); branches off `master`.